### PR TITLE
Add Microsoft Hyper-V reserved range

### DIFF
--- a/sift.js
+++ b/sift.js
@@ -175,8 +175,10 @@ var Sifter = (function() {
 
             /** Microsoft */
             new Mac('00-03-FF-', true, false),
+            /** Hyper-V */
+            new Mac('00-15-5D-', true, false),
 
-            /** Parallells */
+            /** Parallels */
             new Mac('00-1C-42-', true, false),
 
             /** Xen, VBox */


### PR DESCRIPTION
Filter out "burnedIn" for Hyper-V addresses.

Documentation:
* https://macaddress.io/faq/how-to-recognise-a-microsoft-hyper-v-virtual-machine-by-its-mac-address
* https://blog.yaakov.online/choosing-your-own-mac-address/
* https://superuser.com/questions/960146/hyper-v-physical-nic-mac-and-virtual-switch-mac
* https://www.ivobeerens.nl/2014/01/13/check-for-duplicate-mac-address-pools-in-your-hyper-v-environment/

